### PR TITLE
disable eol-last rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,7 @@
       }
     }],
 
+    "eol-last": 0,                            // http://eslint.org/docs/rules/eol-last.html
     "no-extra-parens": 0,                     // http://eslint.org/docs/rules/no-extra-parens
     "react/jsx-boolean-value": 0              // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
   }


### PR DESCRIPTION
Denne vil jeg gjerne ha en diskusjon på.
Er irritrende å ha en error mens du skriver på siste linjen i en fil fordi du skal en en tom linje til slutt, og det er ofte det ikke er det første du tenker på, men heller om du glemt å lukke en bracket osv.

> Benefits of trailing newlines include the ability to concatenate or append to files as well as output files to the terminal without interfering with shell prompts.

Har ikke behov for dette, men vi har jo alle på den settingen som gjør at det blir en EOL på save i sublime/atom, så dette blir enforcet uansett.

Discuss.
