### PR TITLE
Move plugins from dev-dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "index.js"
   ],
   "dependencies": {
-    "eslint-config-airbnb": "^12.0.0"
-  },
-  "devDependencies": {
     "eslint": "^3.8.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-react": "^6.4.1",
+    "eslint-config-airbnb": "^12.0.0"
+  },
+  "devDependencies": {
     "greenkeeper-postpublish": "^1.0.1"
   }
 }


### PR DESCRIPTION
The plugins are not optional, they are dependent upon for this config to work.

With this change you can add this config without having to install 4 other packages as well.
