### PR TITLE
Remove eslint as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "index.js"
   ],
   "dependencies": {
-    "eslint": "^3.8.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-react": "^6.4.1",


### PR DESCRIPTION
Eslint has to be installed by the user for it to be accessible in the node_modules/.bin folder making it redundant for us to depend on it.
