### PR TITLE
Allow object and array propTypes, but keep any

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,5 +19,6 @@ module.exports = {
     'no-param-reassign': [2, { props: false }],
     semi: [2, 'never'],
     'react/jsx-filename-extension': [1, { extensions: ['.js'] }],
+    'react/forbid-prop-types': 1, ['any']
   },
 }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,6 @@ module.exports = {
     'no-param-reassign': [2, { props: false }],
     semi: [2, 'never'],
     'react/jsx-filename-extension': [1, { extensions: ['.js'] }],
-    'react/forbid-prop-types': 1, ['any']
+    'react/forbid-prop-types': [1, { forbid: ['any'] }],
   },
 }


### PR DESCRIPTION
airbnb disallows `propTypes.object` and `propTypes.array` which is to big of a headache, and causes [a lot of bugs](https://github.com/airbnb/javascript/issues/1099).

The rule still disallows `propTypes.any` because I can't find a good example where that should be used instead of `propTypes.oneOfType([…`.
