### PR TITLE
extend eslint-config-react-app instead of airbnb

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
 module.exports = {
   parser: 'babel-eslint',
-  extends: ['eslint-config-airbnb'].map(require.resolve),
+  extends: ['eslint-config-react-app'].map(require.resolve),
   plugins: ['eslint-plugin-appjson'],
-  env: {
-    browser: true,
-  },
   rules: {
     'appjson/require-process-env-defined': [1, ['NODE_ENV']],
     'arrow-parens': [2, 'as-needed'],
@@ -21,7 +18,5 @@ module.exports = {
     'no-param-reassign': [2, { props: false }],
     semi: [2, 'never'],
     'react/jsx-filename-extension': [1, { extensions: ['.js'] }],
-    'react/forbid-prop-types': [1, { forbid: ['any'] }],
-    'react/require-default-props': 0,
   },
 }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   ],
   "dependencies": {
     "babel-eslint": "^7.0.0",
-    "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-react-app": "^1.0.5",
     "eslint-plugin-appjson": "^0.1.2",
+    "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.1.0"
   },
   "devDependencies": {
-    "eslint": "^3.15.0"
+    "eslint": "^3.19.0"
   }
 }


### PR DESCRIPTION
Testing out if this plus prettier is enough.

You can test it with: `npm i --save-dev https://github.com/unfold/eslint-config#react-app`